### PR TITLE
feat: update download button icon

### DIFF
--- a/src/assets/icons/image.svg
+++ b/src/assets/icons/image.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px" fill="#5f6368"><path d="M264-288h432L552-480 444-336l-72-96-108 144ZM144-144v-672h672v672H144Zm72-72h528v-528H216v528Zm0 0v-528 528Z"/></svg>

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -106,7 +106,7 @@ import Button from '@/components/helper/ButtonComponent.vue';
       <Button
         @click="changeRoute($event, ROUTE_NAMES.DOWNLOADS)"
         :href="ROUTE_PATHS.DOWNLOADS"
-        icon="download"
+        icon="image"
         as="a"
         tabindex="1"
       >


### PR DESCRIPTION
Changed the icon of the button to "image" so that the user doesn't expect a direct download.