### PR TITLE
Updated roles and fixed typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       name="description"
       content="Sprache formt Wirklichkeit - daher waren Worte schon immer Bestandteil politischer Propaganda. Kannst du die 1930er und die 2020er Jahre auseinanderhalten?"
     />
-    <meta name="date" content="2025-01-29" />
+    <meta name="date" content="2026-05-17" />
     <meta property="og:title" content="AfD oder NSDAP - Von welcher Partei stammt das Zitat?" />
     <meta
       property="og:description"

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,37 +1,37 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 <url>
 	<loc>https://afdodernsdap.de/</loc>
-	<lastmod>2025-04-16T18:08:05+01:00</lastmod>
+	<lastmod>2026-05-17T13:00:00+01:00</lastmod>
 	<priority>1.0</priority>
 </url>
 <url>
 	<loc>https://afdodernsdap.de/impressum</loc>
-	<lastmod>2025-04-16T18:08:05+01:00</lastmod>
+	<lastmod>2026-05-17T13:00:00+01:00</lastmod>
 	<priority>0.3</priority>
 </url>
 <url>
 	<loc>https://afdodernsdap.de/quiz</loc>
-	<lastmod>2025-04-16T18:08:05+01:00</lastmod>
+	<lastmod>2026-05-17T13:00:00+01:00</lastmod>
 	<priority>0.0</priority>
 </url>
 <url>
 	<loc>https://afdodernsdap.de/about</loc>
-	<lastmod>2025-04-16T18:08:05+01:00</lastmod>
+	<lastmod>2026-05-17T13:00:00+01:00</lastmod>
 	<priority>1.0</priority>
 </url>
 <url>
 	<loc>https://afdodernsdap.de/downloads</loc>
-	<lastmod>2025-04-16T18:08:05+01:00</lastmod>
+	<lastmod>2026-05-17T13:00:00+01:00</lastmod>
 	<priority>0.7</priority>
 </url>
 <url>
 	<loc>https://afdodernsdap.de/quellen</loc>
-	<lastmod>2025-04-16T18:08:05+01:00</lastmod>
+	<lastmod>2026-05-17T13:00:00+01:00</lastmod>
 	<priority>1.0</priority>
 </url>
 <url>
 	<loc>https://afdodernsdap.de/datenschutz</loc>
-	<lastmod>2025-04-16T18:08:05+01:00</lastmod>
+	<lastmod>2026-05-17T13:00:00+01:00</lastmod>
 	<priority>0.3</priority>
 </url>
 </urlset>

--- a/src/components/FooterComponent.vue
+++ b/src/components/FooterComponent.vue
@@ -16,7 +16,7 @@ import { ROUTE_NAMES, ROUTE_PATHS } from '@/router/index';
     </a>
     <div class="footer-imprint">
       <a :href="ROUTE_PATHS.SOURCES" @click="changeRoute($event, ROUTE_NAMES.SOURCES)" tabindex="2"
-        >Stand: 10.02.2025</a
+        >Stand: 17.05.2026</a
       >
       <a :href="ROUTE_PATHS.IMPRINT" @click="changeRoute($event, ROUTE_NAMES.IMPRINT)" tabindex="2">
         Impressum

--- a/src/dataSets/peopleData.ts
+++ b/src/dataSets/peopleData.ts
@@ -25,7 +25,7 @@ export enum People {
 
 const people: Record<People, Person> = {
   [People.ANDREAS_GEHLMAN]: {
-    name: 'Andreas Gehlman',
+    name: 'Andreas Gehlmann',
     position: 'MdL Sachsen-Anhalt (2016 bis 2021)',
     party: Parties.AFD,
   },
@@ -36,7 +36,7 @@ const people: Record<People, Person> = {
   },
   [People.MARKUS_FROHNMAIER]: {
     name: 'Markus Frohnmaier',
-    position: 'MdB (seit 2017), Co-Vorsitzender AfD-Landesverband Baden-Württemberg',
+    position: 'MdB (seit 2017), Landesvorsitzender AfD Baden-Württemberg (seit 2022)',
     party: Parties.AFD,
   },
   [People.ANDREAS_WINHART]: {
@@ -56,7 +56,7 @@ const people: Record<People, Person> = {
   },
   [People.MAXIMILIAN_KRAH]: {
     name: 'Maximilian Krah',
-    position: 'MdEP (seit 2019)',
+    position: 'MdEP (2019 bis 2025), MdB (seit 2025)',
     party: Parties.AFD,
   },
   [People.HERMANN_GOERING]: {
@@ -106,7 +106,7 @@ const people: Record<People, Person> = {
   },
   [People.OLIVER_KIRCHNER]: {
     name: 'Oliver Kirchner',
-    position: 'Mdl Sachsen-Anhalt (seit 2018)',
+    position: 'MdL Sachsen-Anhalt (seit 2018)',
     party: Parties.AFD,
   },
   [People.BERND_BAUMANN]: {
@@ -116,7 +116,7 @@ const people: Record<People, Person> = {
   },
   [People.BEATRIX_VON_STORCH]: {
     name: 'Beatrix von Storch',
-    position: 'MdB (seit 2017), stellvertretende Bundessprecherin und Fraktionsvorsitzende der AfD',
+    position: 'MdB (seit 2017), stellvertretende Vorsitzende der AfD-Bundestagsfraktion',
     party: Parties.AFD,
   },
 };

--- a/src/dataSets/quoteData.ts
+++ b/src/dataSets/quoteData.ts
@@ -711,7 +711,7 @@ const quoteData: Quote[] = [
         title: 'ECLI:DE:BGH:2023:051023URIZ.R.1.23.0',
         date: '05.10.2023',
         publishingFormat: 'Urteil',
-        url: 'http://juris.bundesgerichtshof.de/cgi-bin/rechtsprechung/document.py?Gericht=bgh&Art=en&client=12&pos=0&anz=1&Blank=1.pdf&nr=135257',
+        url: 'https://juris.bundesgerichtshof.de/cgi-bin/rechtsprechung/document.py?Gericht=bgh&Art=en&client=12&pos=0&anz=1&Blank=1.pdf&nr=135257',
         lastAccessed: '27.01.2025',
       },
     ],

--- a/src/views/SourcesView.vue
+++ b/src/views/SourcesView.vue
@@ -44,6 +44,13 @@ import SourceCollection from '@/components/sources/SourceCollection.vue';
       </p>
       <ul>
         <li>
+          <b>17.05.2026 //</b> Behebung zweier Tippfehler (Andreas Gehlman → Gehlmann, Oliver Kirchner: Mdl → MdL)
+          sowie Aktualisierung und Korrektur der Positionen von Parteimitgliedern der AfD.
+          Maximilian Krah: MdEP (seit 2019) → MdEP (2019 bis 2025), MdB (seit 2025)
+          Beatrix von Storch: MdB (seit 2017), stellvertretende Bundessprecherin und Fraktionsvorsitzende der AfD → MdB (seit 2017), stellvertretende Vorsitzende der AfD-Bundestagsfraktion
+          Markus Frohnmaier: MdB (seit 2017), Co-Vorsitzender AfD-Landesverband Baden-Württemberg → MdB (seit 2017), Landesvorsitzender AfD Baden-Württemberg (seit 2022)
+        </li>
+        <li>
           <b>10.02.2025 //</b> Korrektur eines Tippfehlers im Zitat „Das deutsche Volk ist nicht
           länger mehr gewillt, sich zu beugen!“: Ergänzung eines fehlenden Kommas
         </li>


### PR DESCRIPTION
Updated roles and Typos to a 2026 state.

Behebung zweier Tippfehler (Andreas Gehlman → Gehlmann, Oliver Kirchner: Mdl → MdL)
sowie Aktualisierung und Korrektur der Positionen von Parteimitgliedern der AfD.
Maximilian Krah: MdEP (seit 2019) → MdEP (2019 bis 2025), MdB (seit 2025)
Beatrix von Storch: MdB (seit 2017), stellvertretende Bundessprecherin und Fraktionsvorsitzende der AfD → MdB (seit 2017), stellvertretende Vorsitzende der AfD-Bundestagsfraktion
Markus Frohnmaier: MdB (seit 2017), Co-Vorsitzender AfD-Landesverband Baden-Württemberg → MdB (seit 2017), Landesvorsitzender AfD Baden-Württemberg (seit 2022)